### PR TITLE
Added isOutboundNotification to make handling other notifications easier

### DIFF
--- a/Outbound/Outbound.h
+++ b/Outbound/Outbound.h
@@ -134,6 +134,7 @@ typedef void (^OBOperationCompletion)(BOOL success);
  */
 + (void)identifyGroupWithId:(NSString *)groupId userId:(NSString *)userId groupAttributes:(nullable NSDictionary *)groupAttributes andUserAttributes:(nullable NSDictionary *)userAttributes;
 
++ (BOOL)isOutboundNotification:(NSDictionary *)userInfo;
 + (BOOL)isUninstallTracker:(NSDictionary *)userInfo;
 + (void)handleNotificationWithUserInfo:(NSDictionary *)userInfo completion:(OBOperationCompletion)completion;
 + (void)handleNotificationResponse:(UNNotificationResponse *)response;

--- a/Outbound/Outbound.m
+++ b/Outbound/Outbound.m
@@ -181,6 +181,11 @@ static NSString * const OBNotificationUserInfoKeyOGP = @"_ogp";
     }
 }
 
++ (BOOL)isOutboundNotification:(NSDictionary *)userInfo {
+    // All outbound push notifications, uninstall trackers, or otherwise have _oid.
+    return userInfo[OBNotificationUserInfoKeyIdentifier] != nil || userInfo[OBNotificationUserInfoKeyOTM] != nil || userInfo[OBNotificationUserInfoKeyOGP] != nil;
+}
+
 + (BOOL)isUninstallTracker:(NSDictionary *)userInfo {
     return userInfo[OBNotificationUserInfoKeyOGP] != nil;
 }
@@ -193,8 +198,7 @@ static NSString * const OBNotificationUserInfoKeyOGP = @"_ogp";
     NSParameterAssert(userInfo != nil);
     NSParameterAssert(completion != nil);
 
-    // All outbound push notifications, uninstall trackers, or otherwise have _oid.
-    if (userInfo[OBNotificationUserInfoKeyIdentifier] == nil && userInfo[OBNotificationUserInfoKeyOTM] == nil) {
+    if ([self isOutboundNotification:userInfo]) {
         completion(YES);
         return;
     }


### PR DESCRIPTION
Added `isOutboundNotification` method to make handling other notifications easier.

Now `didReceiveRemoteNotification` can be implemented as:
```objc
- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
    if ([Outbound isOutboundNotification:userInfo]) {
        [Outbound handleNotificationWithUserInfo:userInfo completion:^(BOOL success) {
            completionHandler(success ? UIBackgroundFetchResultNewData : UIBackgroundFetchResultFailed);
        }];
    } else {
        // Hande non-Outbound notifications here
        completionHandler(UIBackgroundFetchResultNoData);
    }
}
```

While `isOutboundNotification` could be rolled into `handleNotificationWithUserInfo`, we felt that keeping them seperate makes the intention of each function clearer and provides more flexibility.

### Changes
- Added `didReceiveRemoteNotification` method to return if a notification is from Outbound or not.